### PR TITLE
maven-compiler-plugin 版本 和 jcseg.properties 默认 加载 顺序文档 的改进

### DIFF
--- a/jcseg-core/src/main/java/org/lionsoul/jcseg/tokenizer/core/JcsegTaskConfig.java
+++ b/jcseg-core/src/main/java/org/lionsoul/jcseg/tokenizer/core/JcsegTaskConfig.java
@@ -151,23 +151,23 @@ public class JcsegTaskConfig implements Cloneable
         this.load(new FileInputStream(proFile));
     }
     
-    /**
-     * initialize the value of its options by auto searching the jcesg.properties file:
-     * 
-     * 1. the path that jcseg-core-{version}.jar located
-     * 2. the classpath - the property file in the jcseg-core-{version}.jar zip file
-     * 3. user home dir
-     * 
-     * @throws  IOException
-    */
+	/**
+	 * initialize the value of its options by auto searching the jcesg.properties file:
+	 * 
+	 * <p>
+	 * 1. Inside the dir that jcseg-core-{version}.jar is located, means beside the jar file.
+	 * <p>
+	 * 2. Search root classpath.
+	 * <li>First, could manually put this file into root classpath (which is outside of any jar file).
+	 * <li>Second, there is a copy of this file inside jcseg-core-{version}.jar. It will be used if didn't manually copy this file into classpath.
+	 * <p>
+	 * 3. Load from system property "user.home".
+	 * 
+	 * @throws IOException
+	 */
     public void autoLoad() throws IOException 
     {
-        /*
-         * 1.load the the jcseg.properties located with the jar file.
-         * 2.load the jcseg.propertiess from the classpath.
-         * 3.load the jcseg.properties from the user.home 
-         */
-        
+    	// Try load the file from beside jcseg-core-{version}.jar.
         File proFile = new File(Util.getJarHome(this)+"/"+LEX_PROPERTY_FILE);
         if ( proFile.exists() ) {
             pFile = proFile.getAbsolutePath();
@@ -175,10 +175,7 @@ public class JcsegTaskConfig implements Cloneable
             return;
         }
         
-        /*
-         * by default we have package a jcseg.properties file
-         * with default setting insite the class path
-        */
+        // Search root classpath, if didn't copy to classpath manually, then will found & use the one inside jcseg-core-{version}.jar.
         InputStream is = this.getClass().getResourceAsStream("/"+LEX_PROPERTY_FILE);
         if ( is != null ) {
             pFile = "classpath/jcseg.properties";
@@ -186,6 +183,7 @@ public class JcsegTaskConfig implements Cloneable
             return;
         }
             
+        // Load from system property "user.home".
         proFile = new File(System.getProperty("user.home")+"/"+LEX_PROPERTY_FILE);
         if ( proFile.exists() ) {
             pFile = proFile.getAbsolutePath();

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <plugins>
     <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>


### PR DESCRIPTION
刚刚用了 jcseg 1.9.9 的版本, 很不错, 但是用的过程中 遇到了一点问题, 并且修改了点.
### 修改内容
1. 下载源码后, 在 eclipse 中 发现 根目录的 `pom.xml` 报错, 是 `maven-compiler-plugin` 没有指定版本号 造成的, 所以加了 `<version>3.1</version>`, 然后就可以成功编译了.
2. `jcseg.properties` 默认 加载 顺序的文档, 看了好几遍, 感觉对新人比较难以完全正确理解, 我也是看了源代码, 然后测试过 才完全确定其逻辑. 所以在 `JcsegTaskConfig`.`autoLoad()` 中, 改进了一下 其 javadoc 和 注释.

如果上面的修改 有不合理, 请告知我, 谢谢!
